### PR TITLE
Move map_page_auto_menu_item_ids to a named function

### DIFF
--- a/admin/class-auto-menu-from-pages-admin.php
+++ b/admin/class-auto-menu-from-pages-admin.php
@@ -226,7 +226,6 @@ class Auto_Menu_From_Pages_Admin {
 	    return $this->get_page_auto_menu_item_id( $page->ID );
 	}
 
-
 	/**
 	 * Force sync auto menu.
 	 *

--- a/admin/class-auto-menu-from-pages-admin.php
+++ b/admin/class-auto-menu-from-pages-admin.php
@@ -217,6 +217,17 @@ class Auto_Menu_From_Pages_Admin {
 	}
 
 	/**
+	 * Map page auto menu item IDs
+	 *
+	 * @since 1.3.1
+	 */
+	public function map_page_auto_menu_item_ids( $page ) {
+
+	    return $this->get_page_auto_menu_item_id( $page->ID );
+	}
+
+
+	/**
 	 * Force sync auto menu.
 	 *
 	 * @since  1.1.0
@@ -341,9 +352,7 @@ class Auto_Menu_From_Pages_Admin {
 		}
 
 		// Get all non-excluded page ID's.
-		$included_menu_item_ids = array_map( function( $page ) {
-			return $this->get_page_auto_menu_item_id( $page->ID );
-		}, $pages );
+		$included_menu_item_ids = array_map( array( $this, 'map_page_auto_menu_item_ids' ), $pages );
 
 		// Remove any items that aren't published or are otherwise excluded.
 		foreach ( $menu_item_ids as $menu_item_id ) {


### PR DESCRIPTION
This commit is a response to a bug report caused by our map_page_auto_menu_item_ids function failing in older versions of php (versions below 5.4). We created a public named function and call it when needed to handle this in older versions. 
